### PR TITLE
improvments in GeneralBandpassInterpolator and related code

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -27,6 +27,7 @@ zip_safe = False
 install_requires =
     astropy>=3.1
     extinction>=0.4.4
+    h5py>=3.12
     numpy>=1.14.5   # 1.14.6 seems to work but not with oldest-supported-numpy
     pyyaml>=3.13
     scipy>=1.3.0

--- a/sncosmo/bandpasses.py
+++ b/sncosmo/bandpasses.py
@@ -44,7 +44,7 @@ def get_bandpass(name, *args, **kwargs):
     >>> sncosmo.get_bandpass("standard::u")
     <Bandpass 'standard::u' at 0x77d6a75f25a0>
 
-    Get the megacampsf variable bandpass in the u band, interpolated at radius 0
+    Get the megacampsf variable bandpass in the u band interpolated at radius 0
 
     >>> sncosmo.get_bandpass("megacampsf::u", 0.)
     <AggregateBandpass 'megacampsf::u at 0.000000' at 0x77d6ba059f40>
@@ -57,7 +57,7 @@ def get_bandpass(name, *args, **kwargs):
     >>> sncosmo.get_bandpass('ztf::g')
     <Bandpass 'ztf::g' at 0x708335df3e30>
 
-    Get the ztf bandpass in the g band, interpolated at pixel (0, 0) of sensor 1
+    Get the ztf bandpass in the g band interpolated at pixel (0, 0) of sensor 1
 
     >>> sncosmo.get_bandpass('ztf::g', x=0, y=0, sensor_id=1)
     <Bandpass 'ztf::g' at 0x7e0605f3b920>

--- a/sncosmo/bandpasses.py
+++ b/sncosmo/bandpasses.py
@@ -35,6 +35,33 @@ def get_bandpass(name, *args, **kwargs):
       the keyword arguments `x`, `y` and `sensor_id`. TODO explain
       `wave`argument.
 
+    Examples
+    --------
+    >>> import sncosmo
+
+    Get the "standard" bandpass in the u band
+
+    >>> sncosmo.get_bandpass("standard::u")
+    <Bandpass 'standard::u' at 0x77d6a75f25a0>
+
+    Get the megacampsf variable bandpass in the u band, interpolated at radius 0
+
+    >>> sncosmo.get_bandpass("megacampsf::u", 0.)
+    <AggregateBandpass 'megacampsf::u at 0.000000' at 0x77d6ba059f40>
+
+    >>> sncosmo.get_bandpass('megacampsf::u', radius=0.)
+    <AggregateBandpass 'megacampsf::u at 0.000000' at 0x77d6bac69ca0>
+
+    Get the ztf bandpass in the g band, averaged over the the focal plane
+
+    >>> sncosmo.get_bandpass('ztf::g')
+    <Bandpass 'ztf::g' at 0x708335df3e30>
+
+    Get the ztf bandpass in the g band, interpolated at pixel (0, 0) of sensor 1
+
+    >>> sncosmo.get_bandpass('ztf::g', x=0, y=0, sensor_id=1)
+    <Bandpass 'ztf::g' at 0x7e0605f3b920>
+
     """
     if isinstance(name, Bandpass):
         return name
@@ -47,7 +74,7 @@ def get_bandpass(name, *args, **kwargs):
     interp = _BANDPASS_INTERPOLATORS.retrieve(name)
     if isinstance(interp, BandpassInterpolator):
         # arguments check: the `pos` argument to BandpassInterpolator.at can be
-        # passed as a positional argument or the 'radius' keyword argument
+        # passed as a positional argument or by the 'radius' keyword argument
         if args and kwargs:
             raise TypeError(
                 'keyword and positional arguments cannot be mixed')

--- a/sncosmo/bandpasses.py
+++ b/sncosmo/bandpasses.py
@@ -497,7 +497,6 @@ class BandpassInterpolator(object):
                                  name=name, family=self.name)
 
 
-# TODO(mbernard) docstring for the class
 class Transforms(object):
     """Map pixel to focal plane and filter coordinates
 
@@ -509,32 +508,28 @@ class Transforms(object):
 
     """
     def __init__(self, to_focalplane, to_filter):
-        self.to_fp = to_focalplane
-        self.to_filt = to_filter
+        self._to_focalplane = to_focalplane
+        self._to_filter = to_filter
+
+    @staticmethod
+    def _to_coords(x, y, sensor_id, coords):
+        x_out = np.zeros_like(x)
+        y_out = np.zeros_like(y)
+        for s_id in np.unique(sensor_id):
+            idx = s_id == sensor_id
+            x_out[idx] = polyval2d(x[idx], y[idx], coords[s_id][0])
+            y_out[idx] = polyval2d(x[idx], y[idx], coords[s_id][1])
+        return x_out, y_out
 
     def to_focalplane(self, x, y, sensor_id):
         """Map x, y, sensor_id to focalplane coordinates"""
-        X = np.zeros_like(x)
-        Y = np.zeros_like(y)
-        for s_id in np.unique(sensor_id):
-            idx = s_id == sensor_id
-            X[idx] = polyval2d(x[idx], y[idx], self.to_fp[s_id][0])
-            Y[idx] = polyval2d(x[idx], y[idx], self.to_fp[s_id][1])
-        return X, Y
+        return self._to_coords(x, y, sensor_id, self._to_focalplane)
 
     def to_filter(self, x, y, sensor_id):
         """Map x, y, sensor_id to filter coordinates"""
-        X = np.zeros_like(x)
-        Y = np.zeros_like(y)
-        for s_id in np.unique(sensor_id):
-            idx = s_id == sensor_id
-            X[idx] = polyval2d(x[idx], y[idx], self.to_filt[s_id][0])
-            Y[idx] = polyval2d(x[idx], y[idx], self.to_filt[s_id][1])
-        return X, Y
+        return self._to_coords(x, y, sensor_id, self._to_filter)
 
 
-# TODO interp1d from scipy is deprecated, use np.interp instead
-# (https://docs.scipy.org/doc/scipy/tutorial/interpolate/1D.html#tutorial-interpolate-1dsection)
 # TODO docstring for class
 class GeneralBandpassInterpolator(object):
     """A slightly modified, and more general interpolator"""

--- a/sncosmo/bandpasses.py
+++ b/sncosmo/bandpasses.py
@@ -522,7 +522,7 @@ class Transforms(object):
             idx = s_id == sensor_id
             X[idx] = polyval2d(x[idx], y[idx], self.to_fp[s_id][0])
             Y[idx] = polyval2d(x[idx], y[idx], self.to_fp[s_id][1])
-        return X,Y
+        return X, Y
 
     def to_filter(self, x, y, sensor_id):
         """Map x,y,key to filter coordinates"""
@@ -532,7 +532,7 @@ class Transforms(object):
             idx = s_id == sensor_id
             X[idx] = polyval2d(x[idx], y[idx], self.to_filt[s_id][0])
             Y[idx] = polyval2d(x[idx], y[idx], self.to_filt[s_id][1])
-        return X,Y
+        return X, Y
 
 
 class GeneralBandpassInterpolator(object):
@@ -549,8 +549,8 @@ class GeneralBandpassInterpolator(object):
         # we also need to track the wavelength range on which all the static
         # transmissions are defined
         wl = np.array(
-            [(tr[:,0].min(), tr[:,0].max()) for tr in static_transmissions])
-        static_wl_range = wl[:,0].max(), wl[:,1].min()
+            [(tr[:, 0].min(), tr[:, 0].max()) for tr in static_transmissions])
+        static_wl_range = wl[:, 0].max(), wl[:, 1].min()
 
         # specific sensor quantum efficiencies
         if specific_sensor_qe is not None:
@@ -567,8 +567,8 @@ class GeneralBandpassInterpolator(object):
         if variable_transmission is not None:
             if len(variable_transmission) == 3:
                 rad, wl, tr = variable_transmission
-                idx = (wl>=static_wl_range[0]) & (wl<=static_wl_range[1])
-                wl, tr = wl[idx], tr[:,idx]
+                idx = (wl >= static_wl_range[0]) & (wl <= static_wl_range[1])
+                wl, tr = wl[idx], tr[:, idx]
                 self.wavegrid = wl
                 self.wave = (wl.min(), wl.max())
                 self.pos = (rad.min(), rad.max())
@@ -577,8 +577,8 @@ class GeneralBandpassInterpolator(object):
                 self.radial = True
             elif len(variable_transmission) == 4:
                 x, y, wl, tr = variable_transmission
-                idx = (wl>=static_wl_range[0]) & (wl<=static_wl_range[1])
-                wl, tr = wl[idx], tr[:,:,idx]
+                idx = (wl >= static_wl_range[0]) & (wl <= static_wl_range[1])
+                wl, tr = wl[idx], tr[:, :, idx]
                 self.wavegrid = wl
                 self.wave = (wl.min(), wl.max())
                 self.pos = (x.min(), y.min()), (x.max(), y.max())
@@ -666,12 +666,12 @@ class GeneralBandpassInterpolator(object):
 
         if self.variable_transmission:
             if not self.radial:
-                XY = np.vstack((X,Y))
+                XY = np.vstack((X, Y))
                 v = np.array([
                     self.variable_transmission(np.array([
                         np.full(len(wl), x),
                         np.full(len(wl), y), wl]).T)
-                    for x,y in XY.T])
+                    for x, y in XY.T])
                 trans = trans * v if trans is not None else v
             else:
                 rad = np.sqrt(X**2 + Y**2)

--- a/sncosmo/bandpasses.py
+++ b/sncosmo/bandpasses.py
@@ -558,7 +558,7 @@ class GeneralBandpassInterpolator(object):
         TODO
     specific_sensor_qe : dict, optional
         TODO
-    variable_transmission : tuple of np.ndarray, optional
+    variable_transmission : list of np.ndarray, optional
         TODO
     transforms : Transforms, optional
         mapping of the (x, y, sensor) coordinates to the corresponding focal

--- a/sncosmo/bandpasses.py
+++ b/sncosmo/bandpasses.py
@@ -20,10 +20,22 @@ _BANDPASSES = Registry()
 _BANDPASS_INTERPOLATORS = Registry()
 
 
-# TODO docstring for that, explaining possible combinations of *args and
-# **kwargs
 def get_bandpass(name, *args, **kwargs):
-    """Get a Bandpass from the registry by name."""
+    """Get a Bandpass from the registry by name.
+
+    When `name` corresponds to a static bandpass, no other argument is
+    accepted. When `name` correponds to a variable bandpass the following
+    arguments are accepted:
+
+    - for megacampsf, the position is specified either as a positional argument
+      or with the keyword argument `radius`.
+
+    - for ztf, megacam6 and hsc, when no arguments are provided an averaged
+      bandpass is returned. A position on the focal plane can be specified with
+      the keyword arguments `x`, `y` and `sensor_id`. TODO explain
+      `wave`argument.
+
+    """
     if isinstance(name, Bandpass):
         return name
 
@@ -498,7 +510,8 @@ class BandpassInterpolator(object):
 
 
 class Transforms(object):
-    """Map pixel to focal plane and filter coordinates
+    """Map the (x, y, sensor_id) coordinates of a star to the corresponding
+    focal plane or filter coordinates
 
     .. note:
 
@@ -530,10 +543,32 @@ class Transforms(object):
         return self._to_coords(x, y, sensor_id, self._to_filter)
 
 
-# TODO docstring for class
+# TODO remove the **keys in constructor
 class GeneralBandpassInterpolator(object):
-    """A slightly modified, and more general interpolator"""
+    """Bandpass generator that supports sensor-to-sensor variations as well as
+    general non-radial patterns in bandpasses.
 
+    Instances of this class are not Bandpasses themselves, but generate
+    Bandpasses at a given (x, y, sensor_id) position. This class stores the
+    transmission as a function of position and interpolates between the defined
+    positions to return the bandpass at an arbitrary position.
+
+    Parameters
+    ----------
+    static_transmissions : list of np.ndarray
+        TODO
+    specific_sensor_qe : dict, optional
+        TODO
+    variable_transmission : tuple of np.ndarray, optional
+        TODO
+    transforms : Transforms, optional
+        mapping of the (x, y, sensor) coordinates to the corresponding focal
+        plane or filter coordinates.
+    prefactor : float, optional
+        Scalar multiplying factor.
+    name : str
+
+    """
     def __init__(self, static_transmissions, specific_sensor_qe=None,
                  variable_transmission=None, transforms=None, prefactor=1.0,
                  name=None, **keys):

--- a/sncosmo/builtins.py
+++ b/sncosmo/builtins.py
@@ -625,6 +625,8 @@ def load_default_bandpasses(relpath, band, version, name=None):
             bandpass['trans'][...],
             name=name)
 
+# TODO(mbernard) implement support for versions as for sources
+
 
 # ZTF variable bandpasses
 ztfv_meta = {

--- a/sncosmo/builtins.py
+++ b/sncosmo/builtins.py
@@ -588,13 +588,20 @@ def load_general_bandpass_interpolator(relpath, band, name=None, version=None):
         to_filter = {
             int(k): v[...] for k, v in f['/transforms/to_filter'].items()}
 
-        tr = Transforms(to_focalplane, to_filter)
+        transforms = Transforms(to_focalplane, to_filter)
 
         g = f['bandpasses'][band]
         if 'radii' in g:
-            vtrans = g['radii'][...], g['wave'][...], g['trans'][...]
+            variable_transmission = (
+                g['radii'][...],
+                g['wave'][...],
+                g['trans'][...])
         elif 'X' in g and 'Y' in g:
-            vtrans = g['X'][...], g['Y'][...], g['wave'][...], g['trans'][...]
+            variable_transmission = (
+                g['X'][...],
+                g['Y'][...],
+                g['wave'][...],
+                g['trans'][...])
         else:  # pragma: no cover
             raise ValueError(
                 'failed to load interpolator from {} for band {}'.format(
@@ -603,10 +610,8 @@ def load_general_bandpass_interpolator(relpath, band, name=None, version=None):
         return GeneralBandpassInterpolator(
             static_transmissions=static_transmissions,
             specific_sensor_qe=specific_sensor_qe,
-            variable_transmission=vtrans,
-            transforms=tr,
-            bounds_error=False,
-            fill_value=0.,
+            variable_transmission=variable_transmission,
+            transforms=transforms,
             name=name)
 
 

--- a/sncosmo/builtins.py
+++ b/sncosmo/builtins.py
@@ -562,64 +562,68 @@ for letter in ('u', 'g', 'r', 'i', 'z', 'y'):
 
 
 def load_general_bandpass_interpolator(filename, band, version, name=None):
-    """Extract variable bandpass information from the HDF5 archive.
+    """Extract variable bandpass information from the HDF5 archive
 
     .. note: In the final version, this function will use DATADIR to fetch
     the HDF5 file from a specific online location. For now, the loader code
     is included here for review purposes.
-    """
-    ret = {}
 
+    """
     with h5py.File(filename, 'r') as f:
         static = f['static']
         static_transmissions = [static[k][...] for k in static]
 
         if 'qe' in f:
-            qemap = f['/qe/map']
-            # specific_sensor_qe = dict([(tuple(map(int, k.split('_'))), v[...]) for k,v in f['/qe/map'].items()])
-            specific_sensor_qe = dict([(int(k), v[...]) for k,v in f['/qe/map'].items()])
+            specific_sensor_qe = {
+                int(k): v[...] for k, v in f['/qe/map'].items()}
         else:
             specific_sensor_qe = None
 
-        to_focalplane = dict([(int(k), v[...]) \
-                              for k,v in f['/transforms/to_focalplane'].items()])
-        to_filter = dict([(int(k), v[...]) \
-                          for k,v in f['/transforms/to_filter'].items()])
+        to_focalplane = {
+            int(k): v[...] for k, v in f['/transforms/to_focalplane'].items()}
+
+        to_filter = {
+            int(k): v[...] for k, v in f['/transforms/to_filter'].items()}
+
         tr = Transforms(to_focalplane, to_filter)
 
         g = f['bandpasses'][band]
         if 'radii' in g:
             vtrans = g['radii'][...], g['wave'][...], g['trans'][...]
-            ret = GeneralBandpassInterpolator(static_transmissions=static_transmissions,
-                                              specific_sensor_qe=specific_sensor_qe,
-                                              variable_transmission=vtrans,
-                                              transforms=tr,
-                                              bounds_error=False,
-                                              fill_value=0.)
+            return GeneralBandpassInterpolator(
+                static_transmissions=static_transmissions,
+                specific_sensor_qe=specific_sensor_qe,
+                variable_transmission=vtrans,
+                transforms=tr,
+                bounds_error=False,
+                fill_value=0.)
         elif 'X' in g and 'Y' in g:
             vtrans = g['X'][...], g['Y'][...], g['wave'][...], g['trans'][...]
-            ret = GeneralBandpassInterpolator(static_transmissions=static_transmissions,
-                                              specific_sensor_qe=specific_sensor_qe,
-                                              variable_transmission=vtrans,
-                                              transforms=tr,
-                                              bounds_error=False,
-                                              fill_value=0.)
+            return GeneralBandpassInterpolator(
+                static_transmissions=static_transmissions,
+                specific_sensor_qe=specific_sensor_qe,
+                variable_transmission=vtrans,
+                transforms=tr,
+                bounds_error=False,
+                fill_value=0.)
 
-        return ret
+        return {}
+
 
 def load_default_bandpasses(filename, band, version, name=None):
-    """extract the static (averaged) bandpass information from the hdf5 archive.
+    """Extract the static (averaged) bandpass information from the HDF5 archive
 
     .. note: In the final version, this function will use DATADIR to fetch the
     HDF5 file from a specific online location. For now, the loader code is
     included here for review purposes.
+
     """
     with h5py.File(filename, 'r') as f:
-        bp = f['averaged_bandpasses'][band]
-        wave = bp['wave'][...]
-        trans = bp['trans'][...]
-        ret = Bandpass(wave, trans, name=name)
-    return ret
+        bandpass = f['averaged_bandpasses'][band]
+        return Bandpass(
+            bandpass['wave'][...],
+            bandpass['trans'][...],
+            name=name)
 
 
 # =============================================================================

--- a/sncosmo/builtins.py
+++ b/sncosmo/builtins.py
@@ -563,7 +563,7 @@ for letter in ('u', 'g', 'r', 'i', 'z', 'y'):
                                             meta=megacam_meta)
 
 
-def load_general_bandpass_interpolator(relpath, band, version, name=None):
+def load_general_bandpass_interpolator(relpath, band, name=None, version=None):
     """Extract variable bandpass information from an HDF5 file.
 
     Return an instance of GeneralBandpassInterpolator created from the HDF5
@@ -606,10 +606,11 @@ def load_general_bandpass_interpolator(relpath, band, version, name=None):
             variable_transmission=vtrans,
             transforms=tr,
             bounds_error=False,
-            fill_value=0.)
+            fill_value=0.,
+            name=name)
 
 
-def load_default_bandpasses(relpath, band, version, name=None):
+def load_default_bandpasses(relpath, band, name=None, version=None):
     """Extract the static (averaged) bandpass information from an HDF5 file.
 
     Return an instance of Bandpass created from the HDF5 file located at
@@ -635,14 +636,16 @@ ztfv_meta = {
     'description': (
         'A re-determination of the ZTF filters by P. Rosnet et al '
         '(ZTF-II IN2P3 participation group)')}
-for band in ('g', 'r', 'I'):
-    name = 'ztf::' + band
-    relpath = 'bandpasses/ztf/ztf_v0.hdf5'
-    _BANDPASS_INTERPOLATORS.register_loader(name,
-                                            load_general_bandpass_interpolator,
-                                            args=(relpath, band),
-                                            version='0.1',
-                                            meta=ztfv_meta)
+for version in ('0',):
+    for band in ('g', 'r', 'I'):
+        name = 'ztf::' + band
+        relpath = 'bandpasses/ztf/ztf_v{}.hdf5'.format(version)
+        _BANDPASS_INTERPOLATORS.register_loader(
+            name,
+            load_general_bandpass_interpolator,
+            args=(relpath, band),
+            version=version,
+            meta=ztfv_meta)
 
 
 # ZTF default bandpasses
@@ -652,14 +655,16 @@ ztfd_meta = {
     'description': (
         'A re-determination of the ZTF filters by P. Rosnet et al '
         '(ZTF-II IN2P3 participation group) - focal plane average')}
-for band in ('g', 'r', 'I'):
-    name = 'ztf::' + band
-    relpath = 'bandpasses/ztf/ztf_v0.hdf5'
-    _BANDPASSES.register_loader(name,
-                                load_default_bandpasses,
-                                args=(relpath, band),
-                                version='0.1',
-                                meta=ztfd_meta)
+for version in ('0',):
+    for band in ('g', 'r', 'I'):
+        name = 'ztf::' + band
+        relpath = 'bandpasses/ztf/ztf_v{}.hdf5'.format(version)
+        _BANDPASSES.register_loader(
+            name,
+            load_default_bandpasses,
+            args=(relpath, band),
+            version=version,
+            meta=ztfd_meta)
 
 
 # megacam6 (re-measurements of the decommissioned MegaCam filters @ LMA)
@@ -669,14 +674,16 @@ megacamv_meta = {
     'description': (
         'A re-determination of the decommissioned MegaCam '
         'filters by M. Betoule and LMA')}
-for band in ('g', 'r', 'i', 'i2', 'z'):
-    name = 'megacam6::' + band
-    relpath = 'bandpasses/megacam/megacam6_v0.hdf5'
-    _BANDPASS_INTERPOLATORS.register_loader(name,
-                                            load_general_bandpass_interpolator,
-                                            args=(relpath, band),
-                                            version='0.1',
-                                            meta=megacamv_meta)
+for version in ('0',):
+    for band in ('g', 'r', 'i', 'i2', 'z'):
+        name = 'megacam6::' + band
+        relpath = 'bandpasses/megacam/megacam6_v{}.hdf5'.format(version)
+        _BANDPASS_INTERPOLATORS.register_loader(
+            name,
+            load_general_bandpass_interpolator,
+            args=(relpath, band),
+            version=version,
+            meta=megacamv_meta)
 
 
 # megacam6 default bandpasses
@@ -686,14 +693,16 @@ megacamd_meta = {
     'description': (
         'A re-determination of the decommissioned MegaCam '
         'filters by M. Betoule and LMA -- focal plane average')}
-for band in ('g', 'r', 'i', 'i2', 'z'):
-    name = 'megacam6::' + band
-    relpath = 'bandpasses/megacam/megacam6_v0.hdf5'
-    _BANDPASSES.register_loader(name,
-                                load_default_bandpasses,
-                                args=(relpath, band),
-                                version='0.1',
-                                meta=megacamd_meta)
+for version in ('0',):
+    for band in ('g', 'r', 'i', 'i2', 'z'):
+        name = 'megacam6::' + band
+        relpath = 'bandpasses/megacam/megacam6_v{}.hdf5'.format(version)
+        _BANDPASSES.register_loader(
+            name,
+            load_default_bandpasses,
+            args=(relpath, band),
+            version=version,
+            meta=megacamd_meta)
 
 
 # HSC - Tanaki  version
@@ -703,14 +712,16 @@ hscv_meta = {
     'description': (
         'A model of the HSC filters - '
         'built on a series of measurements by et al.')}
-for band in ('g', 'r', 'r2', 'i', 'i2', 'z', 'Y'):
-    name = 'hsc::' + band
-    relpath = 'bandpasses/hsc/hsc_v0.hdf5'
-    _BANDPASS_INTERPOLATORS.register_loader(name,
-                                            load_general_bandpass_interpolator,
-                                            args=(relpath, band),
-                                            version='0.1',
-                                            meta=hscv_meta)
+for version in ('0',):
+    for band in ('g', 'r', 'r2', 'i', 'i2', 'z', 'Y'):
+        name = 'hsc::' + band
+        relpath = 'bandpasses/hsc/hsc_v{}.hdf5'.format(version)
+        _BANDPASS_INTERPOLATORS.register_loader(
+            name,
+            load_general_bandpass_interpolator,
+            args=(relpath, band),
+            version=version,
+            meta=hscv_meta)
 
 
 hscd_meta = {
@@ -720,14 +731,16 @@ hscd_meta = {
         'A model of the HSC filters - '
         'built on a series of measurements by et al. -- '
         'focal plane average')}
-for band in ('g', 'r', 'r2', 'i', 'i2', 'z', 'Y'):
-    name = 'hsc::' + band
-    relpath = 'bandpasses/hsc/hsc_v0.hdf5'
-    _BANDPASSES.register_loader(name,
-                                load_default_bandpasses,
-                                args=(relpath, band),
-                                version='0.1',
-                                meta=hscd_meta)
+for version in ('0',):
+    for band in ('g', 'r', 'r2', 'i', 'i2', 'z', 'Y'):
+        name = 'hsc::' + band
+        relpath = 'bandpasses/hsc/hsc_v{}.hdf5'.format(version)
+        _BANDPASSES.register_loader(
+            name,
+            load_default_bandpasses,
+            args=(relpath, band),
+            version=version,
+            meta=hscd_meta)
 
 # =============================================================================
 # Sources

--- a/sncosmo/builtins.py
+++ b/sncosmo/builtins.py
@@ -631,8 +631,6 @@ def load_default_bandpasses(relpath, band, name=None, version=None):
             bandpass['trans'][...],
             name=name)
 
-# TODO(mbernard) implement support for versions as for sources
-
 
 # ZTF variable bandpasses
 ztfv_meta = {

--- a/sncosmo/models.py
+++ b/sncosmo/models.py
@@ -155,7 +155,7 @@ def _bandflux(model, band, time_or_phase, zp, zpsys):
             fsum = _bandflux_single(model, b, time_or_phase[mask])
         except ValueError:
             continue
-            
+
         if zp is not None:
             zpnorm = 10.**(0.4 * zp[mask])
             bandzpsys = zpsys[mask]

--- a/sncosmo/tests/test_bandpasses.py
+++ b/sncosmo/tests/test_bandpasses.py
@@ -112,3 +112,33 @@ def test_megacampsf_bandpass():
             for i in range(len(trans)):
                 print(trans_ref[i], trans[i])
             assert_allclose(trans, trans_ref, rtol=1e-5)
+
+    with pytest.raises(TypeError) as err:
+        sncosmo.get_bandpass('megacampsf::u', x=0)
+    assert 'unexpected keyword argument' in str(err)
+
+    with pytest.raises(TypeError) as err:
+        sncosmo.get_bandpass('megacampsf::u', 0, x=0)
+    assert 'keyword and positional arguments cannot be mixed' in str(err)
+
+    # same bandpass with pos arg or radius kwarg
+    bp1 = sncosmo.get_bandpass('megacampsf::u', 0.)
+    bp2 = sncosmo.get_bandpass('megacampsf::u', radius=0.)
+    assert str(bp1) == str(bp2)
+
+
+@pytest.mark.might_download
+def test_ztf_bandpass():
+    assert isinstance(
+        sncosmo.get_bandpass('ztf::g'),
+        Bandpass)
+    assert isinstance(
+        sncosmo.get_bandpass('ztf::g', x=0, y=0, sensor_id=1),
+        Bandpass)
+    assert isinstance(
+        sncosmo.get_bandpass('ztf::g', x=[0, 0], y=[0, 0], sensor_id=[1, 1]),
+        np.ndarray)
+
+    with pytest.raises(TypeError) as err:
+        sncosmo.get_bandpass('ztf::g', bad_arg=0)
+    assert 'unexpected keyword argument' in str(err)

--- a/sncosmo/tests/test_builtins.py
+++ b/sncosmo/tests/test_builtins.py
@@ -52,6 +52,36 @@ def test_builtins_megacampsf():
 
 
 @pytest.mark.might_download
+def test_builtins_ztf_average():
+    sncosmo.get_bandpass('ztf::g')
+
+
+@pytest.mark.might_download
+def test_builtins_ztf_variable():
+    sncosmo.get_bandpass('ztf::g', x=0, y=0, sensor_id=1)
+
+
+@pytest.mark.might_download
+def test_builtins_megacam_average():
+    sncosmo.get_bandpass('megacam6::g')
+
+
+@pytest.mark.might_download
+def test_builtins_megacam_variable():
+    sncosmo.get_bandpass('megacam6::g', x=1000, y=1000, sensor_id=12)
+
+
+@pytest.mark.might_download
+def test_builtins_hsc_average():
+    sncosmo.get_bandpass('hsc::g')
+
+
+@pytest.mark.might_download
+def test_builtins_hsc_variable():
+    sncosmo.get_bandpass('hsc::g', x=0, y=0, sensor_id=1)
+
+
+@pytest.mark.might_download
 def test_builtins_timeseries_ascii():
     sncosmo.get_source('nugent-sn1a')
 


### PR DESCRIPTION
This pull request introduces the following changes:

- fixed issues in the coding style

- HDF5 files for ztf, hsc and megacam6 variable bandpasses are downloaded from
  the `sncosmo` website. The bandpass loader supports an optionnal `version`
  argument.

- various improvements and simplifications in the code

- unit tests and documentation

The following is still to be done (I need your help @nregnault and Brodie, see the `TODO` comments in `bandpasses.py`):

- [ ] complete the doc in `bandpasses.get_bandpass` function

- [ ] complete the doc in `bandpasses.GeneralBandpassInterpolator` class
